### PR TITLE
openal: openal-soft.org outages, switch to use their GitHub repository

### DIFF
--- a/dependencies/np3-linux/openal/build.py
+++ b/dependencies/np3-linux/openal/build.py
@@ -7,7 +7,7 @@ import glob
 
 
 def run(temp_dir: str):
-    __np__.download_extract("https://www.openal-soft.org/openal-releases/openal-soft-1.21.1.tar.bz2", temp_dir)
+    __np__.download_extract("https://github.com/kcat/openal-soft/archive/refs/tags/1.21.1.tar.gz", temp_dir)
 
     src_dir = glob.glob(os.path.join(temp_dir, "openal*"))[0]
 

--- a/dependencies/np3-macos/openal/build.py
+++ b/dependencies/np3-macos/openal/build.py
@@ -7,7 +7,7 @@ import glob
 
 
 def run(temp_dir: str):
-    __np__.download_extract("https://www.openal-soft.org/openal-releases/openal-soft-1.21.1.tar.bz2", temp_dir)
+    __np__.download_extract("https://github.com/kcat/openal-soft/archive/refs/tags/1.21.1.tar.gz", temp_dir)
 
     src_dir = glob.glob(os.path.join(temp_dir, "openal*"))[0]
 

--- a/dependencies/np3-windows/openal/build.py
+++ b/dependencies/np3-windows/openal/build.py
@@ -7,7 +7,7 @@ import glob
 
 
 def run(temp_dir: str):
-    __np__.download_extract("https://www.openal-soft.org/openal-releases/openal-soft-1.21.1.tar.bz2", temp_dir)
+    __np__.download_extract("https://github.com/kcat/openal-soft/archive/refs/tags/1.21.1.tar.gz", temp_dir)
 
     __np__.setup_compiler_env()
 


### PR DESCRIPTION
https://openal-soft.org/ seems to have been having outages, or is just permanently down.

I feel their GitHub repository is the best alternative to it.