### PR TITLE
png: Fix include directory for macOS

### DIFF
--- a/dependencies/np3-macos/png/build.py
+++ b/dependencies/np3-macos/png/build.py
@@ -25,4 +25,4 @@ def run(temp_dir: str):
     __np__.run_with_output("make", "install")
 
     __np__.install_dep_libs("png", os.path.join(prefix_dir, "lib", "*"))
-    __np__.install_dep_include("png", os.path.join(prefix_dir, "include", "**", "*.h"), base_dir=os.path.join(prefix_dir, "include"))
+    __np__.install_dep_include("png", os.path.join(prefix_dir, "include", "*.h"), base_dir=os.path.join(prefix_dir, "include"))


### PR DESCRIPTION
Fix dependency for png on macOS, the current include directory set will cause the following error when compiling and building the wheel for Panda3D.

Log:
```
panda/src/pnmimagetypes/config_pnmimagetypes.h:23:10: fatal error: 'png.h' file not found
#include <png.h>
         ^~~~~~~
1 error generated.
The following command returned a non-zero value: clang++ -std=gnu++11 -ftemplate-depth-70 -fPIC -c -o built/tmp/p3pnmimagetypes_composite1.o -Ibuilt/tmp -Ibuilt/include -Ithirdparty/darwin-libs-a/eigen/include -Ithirdparty/darwin-libs-a/tiff/include -Ithirdparty/darwin-libs-a/jpeg/include -Ithirdparty/darwin-libs-a/png/include -Ithirdparty/darwin-libs-a/zlib/include -DALL_STATIC= -DLINK_ALL_STATIC= -Ipanda/src/pnmimagetypes -Ipanda/src/pnmimage -Wno-deprecated-declarations -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -mmacosx-version-min=11.0 -pthread -fexceptions -msse2 -fno-strict-aliasing -ffast-math -fno-stack-protector -fno-unsafe-math-optimizations -O3 -DNDEBUG -Wall -Wno-unused-function -Wno-reorder -Wno-unused-variable -DBUILDING_PANDA panda/src/pnmimagetypes/p3pnmimagetypes_composite1.cxx
Storing dependency cache.
Elapsed Time: 6 min 57 sec
Build process aborting.
Build terminated.
```