### PR TITLE
Update freetype URL to sourceforge

### DIFF
--- a/dependencies/np3-linux/freetype/build.py
+++ b/dependencies/np3-linux/freetype/build.py
@@ -7,7 +7,7 @@ import glob
 
 
 def run(temp_dir: str):
-    __np__.download_extract("http://download-mirror.savannah.gnu.org/releases/freetype/freetype-2.7.1.tar.gz", temp_dir)
+    __np__.download_extract("https://master.dl.sourceforge.net/project/freetype/freetype2/2.7.1/freetype-2.7.1.tar.gz", temp_dir)
 
     src_dir = glob.glob(os.path.join(temp_dir, "freetype*"))[0]
 

--- a/dependencies/np3-linux/harfbuzz/build.py
+++ b/dependencies/np3-linux/harfbuzz/build.py
@@ -11,7 +11,7 @@ def run(temp_dir: str):
     # We will build freetype first here and then base off that, but we will also have a separate freetype package.
     ft_dir = os.path.join(temp_dir, 'ft')
 
-    __np__.download_extract("http://download-mirror.savannah.gnu.org/releases/freetype/freetype-2.7.1.tar.gz", ft_dir)
+    __np__.download_extract("https://master.dl.sourceforge.net/project/freetype/freetype2/2.7.1/freetype-2.7.1.tar.gz", ft_dir)
 
     ft_src_dir = glob.glob(os.path.join(ft_dir, "freetype*"))[0]
 

--- a/dependencies/np3-macos/freetype/build.py
+++ b/dependencies/np3-macos/freetype/build.py
@@ -8,7 +8,7 @@ import sysconfig
 
 
 def run(temp_dir: str):
-    __np__.download_extract("http://download-mirror.savannah.gnu.org/releases/freetype/freetype-2.7.1.tar.gz", temp_dir)
+    __np__.download_extract("https://master.dl.sourceforge.net/project/freetype/freetype2/2.7.1/freetype-2.7.1.tar.gz", temp_dir)
 
     src_dir = glob.glob(os.path.join(temp_dir, "freetype*"))[0]
 

--- a/dependencies/np3-macos/harfbuzz/build.py
+++ b/dependencies/np3-macos/harfbuzz/build.py
@@ -13,7 +13,7 @@ def run(temp_dir: str):
     # We will build freetype first here and then base off that, but we will also have a separate freetype package.
     ft_dir = os.path.join(temp_dir, 'ft')
 
-    __np__.download_extract("http://download-mirror.savannah.gnu.org/releases/freetype/freetype-2.7.1.tar.gz", ft_dir)
+    __np__.download_extract("https://master.dl.sourceforge.net/project/freetype/freetype2/2.7.1/freetype-2.7.1.tar.gz", ft_dir)
 
     ft_src_dir = glob.glob(os.path.join(ft_dir, "freetype*"))[0]
 

--- a/dependencies/np3-windows/freetype/build.py
+++ b/dependencies/np3-windows/freetype/build.py
@@ -7,7 +7,7 @@ import glob
 
 
 def run(temp_dir: str):
-    __np__.download_extract("http://download-mirror.savannah.gnu.org/releases/freetype/freetype-2.7.1.tar.gz", temp_dir)
+    __np__.download_extract("https://master.dl.sourceforge.net/project/freetype/freetype2/2.7.1/freetype-2.7.1.tar.gz", temp_dir)
 
     __np__.setup_compiler_env()
 

--- a/dependencies/np3-windows/harfbuzz/build.py
+++ b/dependencies/np3-windows/harfbuzz/build.py
@@ -11,7 +11,7 @@ def run(temp_dir: str):
     # We will build freetype first here and then base off that, but we will also have a separate freetype package.
     ft_dir = os.path.join(temp_dir, 'ft')
 
-    __np__.download_extract("http://download-mirror.savannah.gnu.org/releases/freetype/freetype-2.7.1.tar.gz", ft_dir)
+    __np__.download_extract("https://master.dl.sourceforge.net/project/freetype/freetype2/2.7.1/freetype-2.7.1.tar.gz", ft_dir)
 
     __np__.setup_compiler_env()
 


### PR DESCRIPTION
The mirror was down for me earlier today. Sourceforge will be more reliable (as well as uses https)